### PR TITLE
fixed broken fork me on github image banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -78,7 +78,9 @@
     <!-- /.container -->
 </div>
 
-<a href="https://github.com/HotswapProjects/HotswapAgent/fork"><img style="position: absolute; top: 0; right: 0; z-index: 999; border: 0;" src="https://camo.githubusercontent.com/e7bbb0521b397edbd5fe43e7f760759336b5e05f/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png"></a>
+<a href="https://github.com/HotswapProjects/HotswapAgent/fork">
+    <img style="position: absolute; top: 0; right: 0; z-index: 999; border: 0;" src="https://github.blog/wp-content/uploads/2008/12/forkme_right_green_007200.png" alt="Fork me on GitHub">
+</a>
 
 </body>
 {% if site.google_analytics %}


### PR DESCRIPTION
This PR contains the fix for `fork me on github` banner image.

Before:
<img width="1918" height="181" alt="image" src="https://github.com/user-attachments/assets/83759306-bfc4-4081-9178-799ddf897400" />

After fix:
<img width="1918" height="237" alt="image" src="https://github.com/user-attachments/assets/06dac03a-5cc3-4e4b-8d91-c2939fc86291" />
